### PR TITLE
Build1

### DIFF
--- a/TopDeskClient.build.ps1
+++ b/TopDeskClient.build.ps1
@@ -1,13 +1,13 @@
 $Compliance = 1
 
+Get-Item env:BH* | Remove-Item -ErrorAction SilentlyContinue
+Set-BuildEnvironment -ErrorAction Stop
+
 if ($env:BHBuildSystem -eq 'Unknown') {
     $env:Common_TestResultsDirectory = "$env:BHProjectPath/Tests/Results"
 }
 
 task Clean {
-
-    Get-Item env:BH* | Remove-Item -ErrorAction SilentlyContinue
-    Set-BuildEnvironment -ErrorAction Stop
 
     if (Get-Module $env:BHProjectName) {
         Remove-Module $env:BHProjectName

--- a/TopDeskClient.build.ps1
+++ b/TopDeskClient.build.ps1
@@ -119,4 +119,4 @@ task Archive {
 
 task regularBuild Clean, PreTest, Build, Analyze, Test
 
-task fullBuild Clean, PreTest, Build, Analyze, Test, Help, GenDocs, Archive
+task fullBuild Clean, PreTest, Build, Analyze, Test, GenDocs, Archive


### PR DESCRIPTION
Stop updating help md files during build & fix build variables to load early enough for local builds.