### PR TITLE
Fix Get-Incident fields parameter

### DIFF
--- a/Tests/Public/Get-Incident.tests.ps1
+++ b/Tests/Public/Get-Incident.tests.ps1
@@ -181,7 +181,7 @@ Describe "Get-Incident" {
                     fields = 'Number','status'
                 }
                 $param1 = $pobj1.fields -join ','
-                Mock -CommandName Get-APIResponse -MockWith { return 'IncidentwithFields' } -ParameterFilter { $_uri -and $_uri -eq '/tas/api/incidents?&fields=' + $param1 + '&use_standard_response=true' } -Verifiable
+                Mock -CommandName Get-APIResponse -MockWith { return 'IncidentwithFields' } -ParameterFilter { $_uri -and $_uri -eq '/tas/api/incidents?&$fields=' + $param1 + '&use_standard_response=true' } -Verifiable
                 
                 $incident = ($pobj1 | Get-Incident)
 
@@ -331,7 +331,7 @@ Describe "Get-Incident" {
 
             Context "Incident by Fields" {
                 $param1 = 'Number','Status'
-                Mock -CommandName Get-APIResponse -MockWith { return 'IncidentbyFields' } -ParameterFilter { $_uri -and $_uri -eq '/tas/api/incidents?&fields=' + ($param1 -join ',') + '&use_standard_response=true' } -Verifiable
+                Mock -CommandName Get-APIResponse -MockWith { return 'IncidentbyFields' } -ParameterFilter { $_uri -and $_uri -eq '/tas/api/incidents?&$fields=' + ($param1 -join ',') + '&use_standard_response=true' } -Verifiable
                 $incident = (Get-Incident -fields $param1)
 
                 It "Should return a value" {

--- a/TopDeskClient/Public/Get-Incident.ps1
+++ b/TopDeskClient/Public/Get-Incident.ps1
@@ -434,7 +434,7 @@ function Get-Incident {
                         }
         
                         'fields' {
-                            $_uri += '&fields=' + ($fields -join ',')
+                            $_uri += '&$fields=' + ($fields -join ',')
                             break
                         }
         


### PR DESCRIPTION
Fix fields parameter to limit returned fields to only those specified - closes #22 
Update test with correct parameter as well ('$fields')