### PR TITLE
Fix param validation for securestring

### DIFF
--- a/TopDeskClient/Public/New-Person.ps1
+++ b/TopDeskClient/Public/New-Person.ps1
@@ -151,7 +151,6 @@ function New-Person {
       ValueFromPipelineByPropertyName = $true,
       ParameterSetName = 'Default')]
     [ValidateNotNullOrEmpty()]
-    [ValidateLength(1, 200)]
     [securestring]
     $password,
 


### PR DESCRIPTION
Remove length validation (_invalid_) from securestring parameter